### PR TITLE
Uses port 3001 as default port for the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ cd front
 yarn install --check-files
 yarn start
 ```
-`yarn start` will say that port `3000` is already in use (by the Rails API) and ask if you would like to run the app on another port. Enter yes. It will use the port `3001`.
 
 ### Open browser
 

--- a/front/package.json
+++ b/front/package.json
@@ -29,7 +29,7 @@
     "typescript": "~3.8"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Modified package.json so yarn starts application in port 3001 by default. Updated README.md accordingly.