### PR TITLE
Adds a docker-compose file for the database server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ This project consists of a frontend in React (/front) and a Ruby on Rails API.
 
 ## Backend (Ruby on Rails API)
 
+### Database
+
+You'll need a PostreSQL database to run the application.
+
+There is a ```docker-compose-yml``` file which will start a PostreSQL and a pgAdmin servers. You will need docker and docker-compose installed in your system. Just run ```docker-compose up``` and you should have a postgresql server available for the project. 
+
+You can acess pgadmin with your browser at http://localhost:8080 (User is "devuser", password "devuser". It will ask a password when connecting to a database, just leave it blank and press enter) You can also access the database server using the command-line client: ```psql "user=devuser password=devuser host=localhost port=5432 dbname=notes_dev"```
+
+The servers can be run separately with ```docker-compose up database -d``` for the database and ```docker-compose up pgadmin -d``` for pgAdmin.
+
+To completely remove the containers and volumes (note that this will destroy all data): ```docker-compose down -v```
+
 ### Create and populate database with seed data
 ```
 cp config/database.yml.example config/database.yml

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -6,10 +6,16 @@ default: &default
 development:
   <<: *default
   database: notes_dev
+  username: devuser
+  host: localhost
+  port: 5432
 
 test:
   <<: *default
   database: notes_test
+  username: testuser
+  host: localhost
+  port: 5432
 
 production:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.4'
+
+services:  
+
+  database:
+    image: postgres:12.1
+    # user: "${UID}:${GID}"
+    # Temporary
+    ports:
+      - 5432:5432
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./docker/database_init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - notesclub
+
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: devuser
+      PGADMIN_DEFAULT_PASSWORD: devuser
+    ports:
+      - 8080:80
+    volumes:
+      - pga4volume:/var/lib/pgadmin
+      - ./docker/pgadmin4_servers.json:/pgadmin4/servers.json
+    networks:
+      - notesclub
+    logging:
+        driver: none
+
+volumes:
+  db_data:
+  pga4volume:
+    
+networks:
+  notesclub:    

--- a/docker/database_init.sql
+++ b/docker/database_init.sql
@@ -1,0 +1,5 @@
+CREATE USER devuser;
+ALTER USER devuser WITH SUPERUSER;
+
+CREATE USER testuser;
+ALTER USER testuser WITH SUPERUSER;

--- a/docker/pgadmin4_servers.json
+++ b/docker/pgadmin4_servers.json
@@ -1,0 +1,13 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "notesclub",
+            "Group": "Servers",
+            "Port": 5432,
+            "Username": "devuser",
+            "Host": "database",
+            "SSLMode": "prefer",
+            "MaintenanceDB": "postgres"
+        }
+    }
+}


### PR DESCRIPTION
I've included a docker-compose configuration so you don't have to install a PostgreSQL server in your machine for development and testing.

Please, make sure that it works fine in your machine before merging the pull request, I've tested only on Ubuntu 20.04 hosts. You will need to update your dabase.yml configuration, see database.yml.example.

If you already have a pg server in your machine maybe you have a port conflict: stop your server to test the docker-compose file or change the port from 5432 to another one in configuration files: docker-compose.yml, database.yml and pgadmin_servers.json if you want to use pgadmin (you will need to destroy the pgadmin container and create it again to load changes in that last file)
