### PR TITLE
Downgrades pgadmin version. Corrects an error in pgadmin4 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There is a `docker-compose-yml` file which will start a PostreSQL and a pgAdmin 
 docker-compose up
 ```
 
-You can acess pgadmin with your browser at http://localhost:8080 (User is "devuser", password "devuser". It will ask a password when connecting to a database, just leave it blank and press enter) You can also access the database server using the command-line client: `psql "user=devuser password=devuser host=localhost port=5432 dbname=notes_dev"`
+You can acess pgadmin with your browser at http://localhost:8080 (User is "devuser", password "devuser". It will ask a password when connecting to a database, just leave it blank and press enter) You can also access the database server using the command-line client: `psql "user=devuser password=devuser host=localhost port=5433 dbname=notes_dev"`
 
 The servers can be run separately with `docker-compose up database -d` for the database and `docker-compose up pgadmin -d` for pgAdmin.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - notesclub
 
   pgadmin:
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:4.25
     environment:
       PGADMIN_DEFAULT_EMAIL: devuser
       PGADMIN_DEFAULT_PASSWORD: devuser

--- a/docker/pgadmin4_servers.json
+++ b/docker/pgadmin4_servers.json
@@ -3,7 +3,7 @@
         "1": {
             "Name": "notesclub",
             "Group": "Servers",
-            "Port": 5433,
+            "Port": 5432,
             "Username": "devuser",
             "Host": "database",
             "SSLMode": "prefer",


### PR DESCRIPTION
There is an error with pgadmin4:4.26, so I downgraded it to 4.25. It seems to work fine with that version.