### PR TITLE
.env configuration for development and test environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and update it if needed
+
+# We can't use 'export' here because file is readed by docker-compose, too
+REACT_APP_NOTESCLUB_API_BASE_URL=http://localhost:3000
+REACT_APP_NOTESCLUB_FRONT_BASE_URL=http://localhost:3001

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore environment variables definition
+/.env
+
 # Ignore bundler config.
 /.bundle
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
       devise (~> 4.0)
       warden-jwt_auth (~> 0.4)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     dry-auto_inject (0.7.0)
       dry-container (>= 0.3.4)
     dry-configurable (0.11.6)
@@ -274,6 +278,7 @@ DEPENDENCIES
   byebug
   database_cleaner
   devise-jwt (~> 0.6.0)
+  dotenv-rails
   guard
   guard-rspec
   jbuilder (~> 2.10.0)

--- a/README.md
+++ b/README.md
@@ -40,14 +40,17 @@ email: marie@curie.com
 password: mariecurie
 ```
 
-### Add env variables to bash_profile
+### Configure env variables
+In development and test environments variables are readed from ```./.env``` file. You should copy the provided ```./.env.example``` file to ```.env```  before running the project. This will affect front and backend environment variables.
+
+Alternatively, you can add environment variables to your bash_profile:
 ```
 # open ~/.bash_profile
 export REACT_APP_NOTESCLUB_API_BASE_URL=http://localhost:3000
 export REACT_APP_NOTESCLUB_FRONT_BASE_URL=http://localhost:3001
 ```
 
-Now run `source ~/.bash_profile` or open a new console to apply the changes.
+Then  run `source ~/.bash_profile` or open a new console to apply the changes.
 
 ### Start server
 ```

--- a/front/package.json
+++ b/front/package.json
@@ -33,9 +33,9 @@
     "typescript": "~3.8"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "PORT=3001 bundle exec dotenv -f ../.env react-scripts start",
+    "build": "bundle exec dotenv -f ../.env react-scripts build",
+    "test": "bundle exec dotenv -f ../.env react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/front/package.json
+++ b/front/package.json
@@ -33,9 +33,9 @@
     "typescript": "~3.8"
   },
   "scripts": {
-    "start": "PORT=3001 bundle exec dotenv -f ../.env react-scripts start",
-    "build": "bundle exec dotenv -f ../.env react-scripts build",
-    "test": "bundle exec dotenv -f ../.env react-scripts test",
+    "start": "PORT=3001 bundle exec dotenv -f ../.env react-scripts start || react-scripts start",
+    "build": "bundle exec dotenv -f ../.env react-scripts build  || react-scripts build",
+    "test": "bundle exec dotenv -f ../.env react-scripts test  || react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Instead of exporting environment variables or adding them in ```.bash_profile```, this PR adds support for ```.env``` files. Now, creating a ```.env``` file in root directory will set the variables for backend and frontend each time the project runs, 

This way we avoid running the export commands in the console(s) when you need to run the project and/or polluting ```.bash_profile``` file.

Please comment your environment variables in your ```.bash_profile``` and run backend and frontend together at least once to ensure it's compatible with your SO.