### PR TITLE
[ISS-79] Fetch twitter usernames from GitHub API

### DIFF
--- a/lib/notesclub/accounts.ex
+++ b/lib/notesclub/accounts.ex
@@ -54,7 +54,7 @@ defmodule Notesclub.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  # @spec create_user(map) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
+  @spec create_user(map) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
   def create_user(attrs \\ %{}) do
     attrs
     |> Enum.into(%{

--- a/lib/notesclub/accounts.ex
+++ b/lib/notesclub/accounts.ex
@@ -10,6 +10,7 @@ defmodule Notesclub.Accounts do
   alias Notesclub.Workers.UserSyncWorker
 
   require Logger
+
   @doc """
   Returns the list of users.
 
@@ -57,21 +58,17 @@ defmodule Notesclub.Accounts do
   def create_user(attrs \\ %{}) do
     attrs
     |> Enum.into(%{
-      username: nil,
       name: nil,
-      twitter_username: nil,
-      avatar_url: nil})
-      |> create_user_and_enqueue_sync_if_necessary()
-
-    # %User{}
-    # |> User.changeset(attrs)
-    # |> Repo.insert()
+      twitter_username: nil
+    })
+    |> create_user_and_enqueue_sync_if_necessary()
   end
 
-  defp create_user_and_enqueue_sync_if_necessary(%{name: nil} = attrs), do: create_user_and_enqueue_sync(attrs)
+  defp create_user_and_enqueue_sync_if_necessary(%{name: nil} = attrs),
+    do: create_user_and_enqueue_sync(attrs)
 
-  defp create_user_and_enqueue_sync_if_necessary(%{twitter_username: nil} = attrs), do: create_user_and_enqueue_sync(attrs)
-
+  defp create_user_and_enqueue_sync_if_necessary(%{twitter_username: nil} = attrs),
+    do: create_user_and_enqueue_sync(attrs)
 
   defp create_user_and_enqueue_sync_if_necessary(attrs) do
     %User{}
@@ -105,23 +102,6 @@ defmodule Notesclub.Accounts do
 
         {:error, changeset}
     end
-
-    # |> case do
-    #   _ -> IO.inspect("got to end")
-    #   # {:ok, %{repo: repo}} ->
-    #   #   {:ok, repo}
-
-    #   # {:error, :repo, changeset, _} ->
-    #   #   {:error, changeset}
-
-    #   # {:error, :repo_default_branch_worker, changeset, _} ->
-    #   #   Logger.error(
-    #   #     "create_repo failed in repo_default_branch_worker. This should never happen. attrs: #{inspect(attrs)}"
-    #   #   )
-
-    #   #   {:error, changeset}
-    # end
-
   end
 
   @doc """

--- a/lib/notesclub/accounts.ex
+++ b/lib/notesclub/accounts.ex
@@ -92,7 +92,18 @@ defmodule Notesclub.Accounts do
     )
     |> Repo.transaction()
     |> case do
-      _ -> IO.inspect("Finish")
+      {:ok, %{user: user}} ->
+        {:ok, user}
+
+      {:error, :user, changeset, _} ->
+        {:error, changeset}
+
+      {:error, :user_default_branch_worker, changeset, _} ->
+        Logger.error(
+          "create_user failed in user_default_branch_worker. This should never happen. attrs: #{inspect(attrs)}"
+        )
+
+        {:error, changeset}
     end
 
     # |> case do

--- a/lib/notesclub/accounts/user.ex
+++ b/lib/notesclub/accounts/user.ex
@@ -5,6 +5,7 @@ defmodule Notesclub.Accounts.User do
   schema "users" do
     field :username, :string
     field :avatar_url, :string
+    field :twitter_username, :string
     has_many :notebooks, Notesclub.Notebooks.Notebook
     timestamps()
   end
@@ -12,7 +13,7 @@ defmodule Notesclub.Accounts.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:username, :avatar_url])
+    |> cast(attrs, [:username, :avatar_url, :twitter_username])
     |> validate_required([:username])
     |> unique_constraint(:username)
   end

--- a/lib/notesclub/accounts/user.ex
+++ b/lib/notesclub/accounts/user.ex
@@ -5,6 +5,7 @@ defmodule Notesclub.Accounts.User do
   schema "users" do
     field :username, :string
     field :avatar_url, :string
+    field :name, :string
     field :twitter_username, :string
     has_many :notebooks, Notesclub.Notebooks.Notebook
     timestamps()
@@ -13,7 +14,7 @@ defmodule Notesclub.Accounts.User do
   @doc false
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:username, :avatar_url, :twitter_username])
+    |> cast(attrs, [:username, :avatar_url, :twitter_username, :name])
     |> validate_required([:username])
     |> unique_constraint(:username)
   end

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -67,14 +67,26 @@ defmodule Notesclub.GithubAPI do
 
   ## Example
   iex> Notesclub.GithubAPI.get_twitter_username([username: "octocat"])
+  {:ok,
+   %GithubAPI{
+     user_info: [
+       %{
+         github_real_name: "octo's realname",
+         github_twitter_username: "twitter_octo",
+       },
+       ...
+     ],
+     ...
+   }}
+  ]"}
 
   iex> Notesclub.GithubAPI.get_twitter_username([username: -1])
-  {:error, :not_found}
+  {:error, %GithubAPI{response: response, errors: ["Not Found"]}}
 
   Arguments:
   - username can be a string or a positive integer 
   """
-  # @spec get_user_info(options()) :: {:ok, map()} | {:error, :not_found}
+  @spec get_user_info(options()) :: {:ok, %GithubAPI{}} | {:error, %GithubAPI{}}
   def get_user_info(options) do
     options
     |> build_url()

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -56,6 +56,28 @@ defmodule Notesclub.GithubAPI do
     |> extract_notebooks_data()
   end
 
+  @doc """
+
+  Using a given username, look up the corresponding user record from Github API 
+
+  ## Example
+  iex> Notesclub.GithubAPI.get_twitter_username([username: "octocat"])
+  {:ok, "octocat"}
+
+  iex> Notesclub.GithubAPI.get_twitter_username([username: -1])
+  {:error, :not_found}
+
+  Arguments:
+  - username can be a string or a positive integer 
+  """
+  @spec get_twitter_username(options()) :: {:ok, %GithubAPI{}} | {:error, %GithubAPI{}}
+  def get_twitter_username(options) do
+    options
+    |> build_url()
+    |> make_request()
+    |> extract_twitter_username()
+  end
+
   defp extract_notebooks_data(%GithubAPI{response: response, errors: errors} = fetch) do
     cond do
       errors[:github_api_key] == ["is missing"] && __MODULE__.check_github_api_key() ->
@@ -63,6 +85,14 @@ defmodule Notesclub.GithubAPI do
 
       true ->
         prepare_data(fetch, response.body["items"])
+    end
+  end
+
+  defp extract_twitter_username(%GithubAPI{response: response}) do
+    case response.status do
+      404 -> {:error, :not_found}
+      200 -> {:ok, response.body["twitter_username"]}
+      _ -> {:error, :not_found}
     end
   end
 

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -75,7 +75,7 @@ defmodule Notesclub.GithubAPI do
   Arguments:
   - username can be a string or a positive integer 
   """
-  @spec get_user_info(String.t()) :: {:ok, map()} | {:error, String.t()}
+  @spec get_user_info(String.t()) :: {:ok, map()} | {:error, atom()}
   def get_user_info(username) do
     username
     |> build_url()
@@ -98,7 +98,7 @@ defmodule Notesclub.GithubAPI do
          200 <- response.status do
       user_info = %{
         twitter_username: response.body["twitter_username"],
-        real_name: response.body["name"]
+        name: response.body["name"]
       }
 
       {:ok, user_info}

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -97,7 +97,7 @@ defmodule Notesclub.GithubAPI do
          200 <- response.status do
       user_info = %{
         github_twitter_username: response.body["twitter_username"],
-        github_username: response.body["name"]
+        github_real_name: response.body["name"]
       }
 
       fetch =

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -11,7 +11,6 @@ defmodule Notesclub.GithubAPI do
           [per_page: number, page: number, order: binary]
           | [username: binary, per_page: number, page: number, order: binary]
   defstruct notebooks_data: nil,
-            user_info: nil,
             total_count: 0,
             response: nil,
             url: nil,

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -66,22 +66,11 @@ defmodule Notesclub.GithubAPI do
   Using a given username, look up the corresponding user record from Github API 
 
   ## Example
-  iex> Notesclub.GithubAPI.get_user_info([username: "octocat"])
-  {:ok,
-   %GithubAPI{
-     user_info: [
-       %{
-         github_real_name: "octo's realname",
-         github_twitter_username: "twitter_octo",
-       },
-       ...
-     ],
-     ...
-   }}
-  ]"}
+  iex> Notesclub.GithubAPI.get_user_info("octocat")
+  {:ok, %{twitter_username: "twitter_octo", name: "octo realname"}
 
-  iex> Notesclub.GithubAPI.get_user_info([username: -1])
-  {:error, %GithubAPI{response: response, errors: ["Not Found"]}}
+  iex> Notesclub.GithubAPI.get_user_info(-1)
+  {:error, :not_found} 
 
   Arguments:
   - username can be a string or a positive integer 

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -163,6 +163,12 @@ defmodule Notesclub.GithubAPI do
     }
   end
 
+  defp build_url(username: username) do
+    %GithubAPI{
+      url: "https://api.github.com/users/#{username}"
+    }
+  end
+
   defp make_request(%GithubAPI{} = fetch) do
     github_api_key = Application.get_env(:notesclub, :github_api_key)
 

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -108,13 +108,11 @@ defmodule Notesclub.GithubAPI do
     with false <- errors[:github_api_key] == ["is missing"],
          200 <- response.status do
       user_info = %{
-        github_twitter_username: response.body["twitter_username"],
-        github_real_name: response.body["name"]
+        twitter_username: response.body["twitter_username"],
+        real_name: response.body["name"]
       }
 
-      fetch =
-        fetch
-        |> Map.put(:user_info, user_info)
+      fetch = %{fetch | user_info: user_info}
 
       {:ok, fetch}
     else

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -66,7 +66,7 @@ defmodule Notesclub.GithubAPI do
   Using a given username, look up the corresponding user record from Github API 
 
   ## Example
-  iex> Notesclub.GithubAPI.get_twitter_username([username: "octocat"])
+  iex> Notesclub.GithubAPI.get_user_info([username: "octocat"])
   {:ok,
    %GithubAPI{
      user_info: [
@@ -80,7 +80,7 @@ defmodule Notesclub.GithubAPI do
    }}
   ]"}
 
-  iex> Notesclub.GithubAPI.get_twitter_username([username: -1])
+  iex> Notesclub.GithubAPI.get_user_info([username: -1])
   {:error, %GithubAPI{response: response, errors: ["Not Found"]}}
 
   Arguments:

--- a/lib/workers/user_sync_worker.ex
+++ b/lib/workers/user_sync_worker.ex
@@ -1,0 +1,21 @@
+defmodule Notesclub.Workers.UserSyncWorker do
+  @moduledoc """
+  Worker to fetch user info and include it during use creation
+  """
+  require Logger
+
+  alias Notesclub.Accounts
+
+  use Oban.Worker,
+    queue: :github_rest,
+    unique: [period: 300, states: [:available, :scheduled, :executing]]
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
+
+    user = Accounts.get_user!(user_id)
+    IO.inspect(user)
+
+    :ok
+  end
+end

--- a/lib/workers/user_sync_worker.ex
+++ b/lib/workers/user_sync_worker.ex
@@ -11,7 +11,8 @@ defmodule Notesclub.Workers.UserSyncWorker do
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
     with user = %{username: username} <- Accounts.get_user!(user_id),
-         {:ok, user_info} <- GithubAPI.get_user_info(username), {:ok, _user} <- Accounts.update_user(user, user_info) do
+         {:ok, user_info} <- GithubAPI.get_user_info(username),
+         {:ok, _user} <- Accounts.update_user(user, user_info) do
       :ok
     else
       {:error, error} -> {:error, error}

--- a/lib/workers/user_sync_worker.ex
+++ b/lib/workers/user_sync_worker.ex
@@ -11,8 +11,7 @@ defmodule Notesclub.Workers.UserSyncWorker do
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
     with user = %{username: username} <- Accounts.get_user!(user_id),
-         {:ok, user_info} <- GithubAPI.get_user_info(username) do
-      Accounts.update_user(user, user_info)
+         {:ok, user_info} <- GithubAPI.get_user_info(username), {:ok, _user} <- Accounts.update_user(user, user_info) do
       :ok
     else
       {:error, error} -> {:error, error}

--- a/lib/workers/user_sync_worker.ex
+++ b/lib/workers/user_sync_worker.ex
@@ -12,14 +12,12 @@ defmodule Notesclub.Workers.UserSyncWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
-
     with user = %{username: username} <- Accounts.get_user!(user_id),
          {:ok, user_info} <- GithubAPI.get_user_info(username) do
-        Accounts.update_user(user, user_info)
-        :ok
+      Accounts.update_user(user, user_info)
+      :ok
     else
       {:error, error} -> {:error, error}
-
     end
   end
 end

--- a/lib/workers/user_sync_worker.ex
+++ b/lib/workers/user_sync_worker.ex
@@ -4,7 +4,7 @@ defmodule Notesclub.Workers.UserSyncWorker do
   """
   require Logger
 
-  alias Notesclub.Accounts
+  alias Notesclub.{Accounts, GithubAPI}
 
   use Oban.Worker,
     queue: :github_rest,
@@ -14,8 +14,15 @@ defmodule Notesclub.Workers.UserSyncWorker do
   def perform(%Oban.Job{args: %{"user_id" => user_id}}) do
 
     user = Accounts.get_user!(user_id)
-    IO.inspect(user)
 
-    :ok
+    response = user
+    |> Map.get(:username)
+    |> GithubAPI.get_user_info()
+
+    case response do
+      {:ok, user_info} -> Accounts.update_user(user, user_info)
+      {:error, error} -> {:error, error}
+    end
+
   end
 end

--- a/lib/workers/user_sync_worker.ex
+++ b/lib/workers/user_sync_worker.ex
@@ -2,8 +2,6 @@ defmodule Notesclub.Workers.UserSyncWorker do
   @moduledoc """
   Worker to fetch user info and include it during user creation
   """
-  require Logger
-
   alias Notesclub.{Accounts, GithubAPI}
 
   use Oban.Worker,

--- a/priv/repo/migrations/20221230164212_add_twitter_username_to_users.exs
+++ b/priv/repo/migrations/20221230164212_add_twitter_username_to_users.exs
@@ -1,9 +1,0 @@
-defmodule Notesclub.Repo.Migrations.AddTwitterUsernameToUsers do
-  use Ecto.Migration
-
-  def change do
-    alter table("users") do
-      add :twitter_username, :string
-    end
-  end
-end

--- a/priv/repo/migrations/20221230164212_add_twitter_username_to_users.exs
+++ b/priv/repo/migrations/20221230164212_add_twitter_username_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Notesclub.Repo.Migrations.AddTwitterUsernameToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      add :twitter_username, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20221231230406_add_name_and_twitter_username_to_user.exs
+++ b/priv/repo/migrations/20221231230406_add_name_and_twitter_username_to_user.exs
@@ -1,0 +1,10 @@
+defmodule Notesclub.Repo.Migrations.AddNameAndTwitterUsernameToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table("users") do
+      add :name, :string
+      add :twitter_username, :string
+    end
+  end
+end

--- a/test/notesclub/accounts_test.exs
+++ b/test/notesclub/accounts_test.exs
@@ -31,7 +31,7 @@ defmodule Notesclub.AccountsTest do
       assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
     end
 
-    test "create_user/1 will create a user without needing a sync" do
+    test "create_user/1 will only create a user without needing a sync" do
       user_no_sync = %{
         username: "test_login_name",
         name: "test_real_name",
@@ -41,9 +41,10 @@ defmodule Notesclub.AccountsTest do
 
       assert {:ok, %User{} = user} = Accounts.create_user(user_no_sync)
       assert user.username == user_no_sync.username
+      refute_enqueued(worker: Notesclub.Workers.UserSyncWorker, args: %{user_id: user.id})
     end
 
-    test "create_user/1 will create and enqueue a update worker" do
+    test "create_user/1 will create and enqueue a update workerif a sync is needed" do
       user_sync = %{username: "test_login_name", avatar_url: "avatar"}
       assert {:ok, %User{} = user} = Accounts.create_user(user_sync)
       assert user.username == user_sync.username

--- a/test/notesclub/accounts_test.exs
+++ b/test/notesclub/accounts_test.exs
@@ -31,6 +31,25 @@ defmodule Notesclub.AccountsTest do
       assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
     end
 
+    test "create_user/1 will create a user without needing a sync" do
+      user_no_sync = %{
+        username: "test_login_name",
+        name: "test_real_name",
+        twitter_username: "test_twitter_name",
+        avatar_url: "avatar"
+      }
+
+      assert {:ok, %User{} = user} = Accounts.create_user(user_no_sync)
+      assert user.username == user_no_sync.username
+    end
+
+    test "create_user/1 will create and enqueue a update worker" do
+      user_sync = %{username: "test_login_name", avatar_url: "avatar"}
+      assert {:ok, %User{} = user} = Accounts.create_user(user_sync)
+      assert user.username == user_sync.username
+      assert_enqueued(worker: Notesclub.Workers.UserSyncWorker, args: %{user_id: user.id})
+    end
+
     test "update_user/2 with valid data updates the user" do
       user = user_fixture()
       update_attrs = %{username: "some updated name"}

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -45,6 +45,21 @@ defmodule Notesclub.GithubAPITest do
     }
   }
 
+  @valid_user_reponse %Req.Response{
+    status: 200,
+    body: %{
+      "id" => 1,
+      "twitter_username" => "test_name"
+    }
+  }
+
+  @invalid_user_reponse %Req.Response{
+    status: 404,
+    body: %{
+      "message" => "Not Found"
+    }
+  }
+
   describe "GithubAPI.Search" do
     test "get/3 returns notebooks" do
       with_mocks([
@@ -109,6 +124,26 @@ defmodule Notesclub.GithubAPITest do
         GithubAPI.get(per_page: 2, page: 1, order: "ASC")
 
       assert length(notebook_data) == 2
+    end
+  end
+
+  describe "get_twitter_username/1" do
+    test "should return {:ok, name} on 200" do
+      with_mocks([
+        {Req, [:passthrough], [get!: fn _url, _options -> @valid_user_reponse end]},
+        {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
+      ]) do
+        assert {:ok, "test_name"} == GithubAPI.get_twitter_username(username: "test_name")
+      end
+    end
+
+    test "should return {:error, :not_found} on 404" do
+      with_mocks([
+        {Req, [:passthrough], [get!: fn _url, _options -> @invalid_user_reponse end]},
+        {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
+      ]) do
+        assert {:error, :not_found} == GithubAPI.get_twitter_username(username: -1)
+      end
     end
   end
 end

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -134,13 +134,11 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @valid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:ok,
-                %Notesclub.GithubAPI{
-                  user_info: %{
+        assert {:ok, %{
                     real_name: "test_name",
                     twitter_username: "test_twitter_name"
                   }
-                }} = GithubAPI.get_user_info(username: "test_name")
+                } = GithubAPI.get_user_info("test_name")
       end
     end
 
@@ -149,8 +147,8 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @invalid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:error, %Notesclub.GithubAPI{errors: ["Not Found"]}} =
-                 GithubAPI.get_user_info(username: -1)
+        assert {:error, :not_found} =
+                 GithubAPI.get_user_info(-1)
       end
     end
   end

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -134,7 +134,13 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @valid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:ok, "test_twitter_name"} == GithubAPI.get_user_info(username: "test_name")
+        assert {:ok,
+                %Notesclub.GithubAPI{
+                  user_info: %{
+                    github_username: "test_name",
+                    github_twitter_username: "test_twitter_name"
+                  }
+                }} = GithubAPI.get_user_info(username: "test_name")
       end
     end
 

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -128,8 +128,8 @@ defmodule Notesclub.GithubAPITest do
     end
   end
 
-  describe "get_twitter_username/1" do
-    test "should return {:ok, name} on 200" do
+  describe "get_user_info/1" do
+    test "should return success response on 200" do
       with_mocks([
         {Req, [:passthrough], [get!: fn _url, _options -> @valid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
@@ -137,14 +137,14 @@ defmodule Notesclub.GithubAPITest do
         assert {:ok,
                 %Notesclub.GithubAPI{
                   user_info: %{
-                    github_username: "test_name",
+                    github_real_name: "test_name",
                     github_twitter_username: "test_twitter_name"
                   }
                 }} = GithubAPI.get_user_info(username: "test_name")
       end
     end
 
-    test "should return {:error, :not_found} on 404" do
+    test "should return error response on 404" do
       with_mocks([
         {Req, [:passthrough], [get!: fn _url, _options -> @invalid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -49,7 +49,8 @@ defmodule Notesclub.GithubAPITest do
     status: 200,
     body: %{
       "id" => 1,
-      "twitter_username" => "test_name"
+      "twitter_username" => "test_twitter_name",
+      "name" => "test_name"
     }
   }
 
@@ -133,7 +134,7 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @valid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:ok, "test_name"} == GithubAPI.get_twitter_username(username: "test_name")
+        assert {:ok, "test_twitter_name"} == GithubAPI.get_user_info(username: "test_name")
       end
     end
 
@@ -142,7 +143,8 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @invalid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:error, :not_found} == GithubAPI.get_twitter_username(username: -1)
+        assert {:error, %Notesclub.GithubAPI{errors: ["Not Found"]}} =
+                 GithubAPI.get_user_info(username: -1)
       end
     end
   end

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -134,11 +134,11 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @valid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:ok, %{
-                    real_name: "test_name",
-                    twitter_username: "test_twitter_name"
-                  }
-                } = GithubAPI.get_user_info("test_name")
+        assert {:ok,
+                %{
+                  name: "test_name",
+                  twitter_username: "test_twitter_name"
+                }} = GithubAPI.get_user_info("test_name")
       end
     end
 
@@ -147,8 +147,7 @@ defmodule Notesclub.GithubAPITest do
         {Req, [:passthrough], [get!: fn _url, _options -> @invalid_user_reponse end]},
         {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
-        assert {:error, :not_found} =
-                 GithubAPI.get_user_info(-1)
+        assert {:error, :not_found} = GithubAPI.get_user_info(-1)
       end
     end
   end

--- a/test/notesclub/github_api_test.exs
+++ b/test/notesclub/github_api_test.exs
@@ -137,8 +137,8 @@ defmodule Notesclub.GithubAPITest do
         assert {:ok,
                 %Notesclub.GithubAPI{
                   user_info: %{
-                    github_real_name: "test_name",
-                    github_twitter_username: "test_twitter_name"
+                    real_name: "test_name",
+                    twitter_username: "test_twitter_name"
                   }
                 }} = GithubAPI.get_user_info(username: "test_name")
       end

--- a/test/notesclub/workers/user_sync_worker_test.exs
+++ b/test/notesclub/workers/user_sync_worker_test.exs
@@ -1,0 +1,57 @@
+defmodule UserSyncWorkerTest do
+  use Notesclub.DataCase
+
+  import Mock
+
+  alias Notesclub.{Accounts, AccountsFixtures}
+  alias Notesclub.Workers.UserSyncWorker
+
+  @github_user_response %Req.Response{
+    status: 200,
+    body: %{
+      "name" => "test_name",
+      "twitter_username" => "test_twitter_username"
+    }
+  }
+
+  @github_no_user_response %Req.Response{
+    status: 404,
+    body: %{
+      "message" => "Not Found"
+    }
+  }
+
+  describe "perform/1" do
+    test "should look up a users github info and update the user" do
+      with_mocks([
+        {Req, [:passthrough], [get!: fn _url, _options -> @github_user_response end]}
+      ]) do
+        user = AccountsFixtures.user_fixture()
+
+        # Run worker:
+       assert :ok = perform_job(UserSyncWorker, %{user_id: user.id})
+
+        # It should have updated user:
+        user = Accounts.get_user!(user.id)
+        assert user.name == "test_name"
+        assert user.twitter_username == "test_twitter_username"
+      end
+    end
+
+    test "should return an error if the user isnt found" do
+      with_mocks([
+        {Req, [:passthrough], [get!: fn _url, _options -> @github_no_user_response end]}
+      ]) do
+        user = AccountsFixtures.user_fixture()
+
+        # Run worker:
+       assert {:error, _error} = perform_job(UserSyncWorker, %{user_id: user.id})
+
+        # It should not have updated user:
+        user = Accounts.get_user!(user.id)
+        assert user.name == nil 
+        assert user.twitter_username == nil
+      end
+    end
+  end
+end

--- a/test/notesclub/workers/user_sync_worker_test.exs
+++ b/test/notesclub/workers/user_sync_worker_test.exs
@@ -3,7 +3,7 @@ defmodule UserSyncWorkerTest do
 
   import Mock
 
-  alias Notesclub.{Accounts, AccountsFixtures}
+  alias Notesclub.{Accounts, AccountsFixtures, GithubAPI}
   alias Notesclub.Workers.UserSyncWorker
 
   @github_user_response %Req.Response{
@@ -24,7 +24,8 @@ defmodule UserSyncWorkerTest do
   describe "perform/1" do
     test "should look up a users github info and update the user" do
       with_mocks([
-        {Req, [:passthrough], [get!: fn _url, _options -> @github_user_response end]}
+        {Req, [:passthrough], [get!: fn _url, _options -> @github_user_response end]},
+        {GithubAPI, [:passthrough], [check_github_api_key: fn -> false end]}
       ]) do
         user = AccountsFixtures.user_fixture()
 

--- a/test/notesclub/workers/user_sync_worker_test.exs
+++ b/test/notesclub/workers/user_sync_worker_test.exs
@@ -29,7 +29,7 @@ defmodule UserSyncWorkerTest do
         user = AccountsFixtures.user_fixture()
 
         # Run worker:
-       assert :ok = perform_job(UserSyncWorker, %{user_id: user.id})
+        assert :ok = perform_job(UserSyncWorker, %{user_id: user.id})
 
         # It should have updated user:
         user = Accounts.get_user!(user.id)
@@ -45,11 +45,11 @@ defmodule UserSyncWorkerTest do
         user = AccountsFixtures.user_fixture()
 
         # Run worker:
-       assert {:error, _error} = perform_job(UserSyncWorker, %{user_id: user.id})
+        assert {:error, _error} = perform_job(UserSyncWorker, %{user_id: user.id})
 
         # It should not have updated user:
         user = Accounts.get_user!(user.id)
-        assert user.name == nil 
+        assert user.name == nil
         assert user.twitter_username == nil
       end
     end


### PR DESCRIPTION
Related Issue: [#79](https://github.com/notesclub/notesclub/issues/79)

This PR adds in an additional end point to call GitHub's API at `https://api.github.com/users/USERNAME`. The following responses are found at the [API documentation](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user).

On a 200 response, we package the user's `name` and `twitter_username` within a `user_info` map and attach it to the `GitHubAPI` struct. 

On a 404 response we return an error tuple with whatever failures are raised.

**Further questions:**

1. I wasn't too sure on the how we'd like the payload to be returned so if there's any modifications you'd like to see let me know!
2. Also, for back filling, did you want that complete in this PR or maybe another? 
3. There were 3 dialyzer errors but they were present on the master branch before any changes. 