### PR TITLE
Set MIX_ENV to test in continuous integration

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,6 +11,9 @@ jobs:
   continuous_integration:
     runs-on: ubuntu-22.04
 
+    env:
+      MIX_ENV: test
+
     services:
       postgres:
         image: postgres:15.0


### PR DESCRIPTION
This avoids recompiling the code twice, since `mix compile` runs by default in the development environment, then `mix test` compiles the code again, but in the test environment, before running the tests.