### PR TITLE
Create /status endpoint to check for recent notebooks

### DIFF
--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -21,6 +21,14 @@ defmodule Notesclub.Notebooks do
   @default_per_page 15
 
   @doc """
+  Returns the latest notebook inserted
+  """
+  @spec get_latest_notebook() :: %Notebook{}
+  def get_latest_notebook() do
+    Notebook |> last(:inserted_at) |> Repo.one()
+  end
+
+  @doc """
   Returns the list of notebooks.
 
   ## Examples

--- a/lib/notesclub_web/controllers/status_controller.ex
+++ b/lib/notesclub_web/controllers/status_controller.ex
@@ -1,5 +1,15 @@
 defmodule NotesclubWeb.StatusController do
   use NotesclubWeb, :controller
 
-  def ok(conn, _params), do: text(conn, "OK")
+  import Notesclub.Notebooks, only: [get_latest_notebook: 0]
+
+  def status(conn, _params) do
+    notebook = get_latest_notebook()
+
+    if Timex.after?(notebook.inserted_at, Timex.now() |> Timex.shift(hours: -48)) do
+      text(conn, "OK")
+    else
+      text(conn, "ERROR. The most recent notebook was created on the #{notebook.inserted_at}")
+    end
+  end
 end

--- a/lib/notesclub_web/router.ex
+++ b/lib/notesclub_web/router.ex
@@ -43,8 +43,7 @@ defmodule NotesclubWeb.Router do
   scope "/", NotesclubWeb do
     pipe_through :browser
 
-    # Used for uptime monitoring and zero-downtime deploys
-    get "/ok", StatusController, :ok
+    get "/status", StatusController, :status
 
     live "/", NotebookLive.Index, :home
     live "/search", NotebookLive.Index, :search

--- a/test/notesclub/notebooks_test.exs
+++ b/test/notesclub/notebooks_test.exs
@@ -23,6 +23,12 @@ defmodule Notesclub.NotebooksTest do
       search: nil
     }
 
+    test "get_latest_notebook/0" do
+      _notebook1 = notebook_fixture(%{inserted_at: ~N[2022-12-31 20:00:00]})
+      notebook2 = notebook_fixture(%{inserted_at: ~N[2023-01-01 20:00:00]})
+      assert Notebooks.get_latest_notebook() == notebook2
+    end
+
     test "list_notebooks/0 ascending order" do
       notebook1 = notebook_fixture()
       notebook2 = notebook_fixture()

--- a/test/notesclub_web/controllers/status_controller_test.exs
+++ b/test/notesclub_web/controllers/status_controller_test.exs
@@ -1,9 +1,23 @@
 defmodule NotesclubWeb.StatusControllerTest do
   use NotesclubWeb.ConnCase
+  import Notesclub.NotebooksFixtures
 
-  test "GET /status returns OK", %{conn: conn} do
-    conn = get(conn, "/ok")
+  test "GET /status returns OK when at least one notebook was inserted in the last 48 hours", %{
+    conn: conn
+  } do
+    notebook_fixture(%{inserted_at: Timex.now() |> Timex.shift(hours: -47)})
+    conn = get(conn, "/status")
 
     assert text_response(conn, 200) == "OK"
+  end
+
+  test "GET /status returns ERROR when no notebook was inserted in the last 48 hours", %{
+    conn: conn
+  } do
+    notebook = notebook_fixture(%{inserted_at: Timex.now() |> Timex.shift(hours: -49)})
+    conn = get(conn, "/status")
+
+    assert text_response(conn, 200) ==
+             "ERROR. The most recent notebook was created on the #{notebook.inserted_at}"
   end
 end


### PR DESCRIPTION
This endpoint replaces the `/ok` endpoint.

Closes #62