### PR TITLE
Lint Elixir code with credo

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,215 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [
+             priority: :low,
+             if_nested_deeper_than: 2,
+             if_called_more_often_than: 0,
+             excluded_namespaces: ["Ecto", "Faker"]
+           ]},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+          {Credo.Check.Design.TagFIXME, []},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.UnsafeExec, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+
+          # {Credo.Check.Refactor.MapInto, []},
+
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -55,5 +55,8 @@ jobs:
       - name: Ensure the Elixir code compiles # https://hexdocs.pm/mix/Mix.Tasks.Compile.html
         run: mix compile --all-warnings --warning-as-errors
 
+      - name: Lint Elixir code to enforce code consistency # Credo's strict analysis: https://hexdocs.pm/credo/basic_usage.html#strict-analysis
+        run: mix credo --strict
+
       - name: Run tests # https://hexdocs.pm/mix/Mix.Tasks.Test.html
         run: mix test

--- a/lib/mix/tasks/insert_users_and_repos.ex
+++ b/lib/mix/tasks/insert_users_and_repos.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.InsertUsersAndRepos do
     start_services()
 
     Notebooks.list_notebooks()
-    |> Enum.map(fn notebook ->
+    |> Enum.each(fn notebook ->
       notebook
       |> find_or_create_user()
       |> find_or_create_repo()

--- a/lib/mix/tasks/insert_users_and_repos.ex
+++ b/lib/mix/tasks/insert_users_and_repos.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.InsertUsersAndRepos do
     :ecto_sql
   ]
 
-  @repos Application.get_env(:notesclub, :ecto_repos, [])
+  @repos Application.compile_env(:notesclub, :ecto_repos, [])
 
   alias Notesclub.Accounts
   alias Notesclub.Notebooks

--- a/lib/mix/tasks/insert_users_and_repos.ex
+++ b/lib/mix/tasks/insert_users_and_repos.ex
@@ -17,9 +17,9 @@ defmodule Mix.Tasks.InsertUsersAndRepos do
 
   @repos Application.get_env(:notesclub, :ecto_repos, [])
 
+  alias Notesclub.Accounts
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
-  alias Notesclub.Accounts
   alias Notesclub.Repos
 
   @shortdoc "Insert users and repos from notebooks and set user_id and repo_id"

--- a/lib/notesclub/accounts.ex
+++ b/lib/notesclub/accounts.ex
@@ -20,7 +20,7 @@ defmodule Notesclub.Accounts do
       [%User{}, ...]
 
   """
-  @spec list_users :: [%User{}]
+  @spec list_users :: [User.t()]
   def list_users do
     Repo.all(User)
   end
@@ -39,7 +39,7 @@ defmodule Notesclub.Accounts do
       ** (Ecto.NoResultsError)
 
   """
-  @spec get_user!(integer) :: %User{}
+  @spec get_user!(integer) :: User.t()
   def get_user!(id), do: Repo.get!(User, id)
 
   @doc """
@@ -54,7 +54,7 @@ defmodule Notesclub.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec create_user(map) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
+  @spec create_user(map) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def create_user(attrs \\ %{}) do
     attrs
     |> Enum.into(%{
@@ -116,7 +116,7 @@ defmodule Notesclub.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec update_user(%User{}, map) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
+  @spec update_user(User.t(), map) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def update_user(%User{} = user, attrs) do
     user
     |> User.changeset(attrs)
@@ -135,7 +135,7 @@ defmodule Notesclub.Accounts do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec delete_user(%User{}) :: {:ok, %User{}} | {:error, %Ecto.Changeset{}}
+  @spec delete_user(User.t()) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def delete_user(%User{} = user) do
     Repo.delete(user)
   end
@@ -150,7 +150,7 @@ defmodule Notesclub.Accounts do
 
   """
 
-  @spec change_user(%User{}, map) :: %Ecto.Changeset{}
+  @spec change_user(User.t(), map) :: Ecto.Changeset.t()
   def change_user(%User{} = user, attrs \\ %{}) do
     User.changeset(user, attrs)
   end
@@ -170,7 +170,7 @@ defmodule Notesclub.Accounts do
   """
   def get_by_username(nil), do: nil
 
-  @spec get_by_username(binary) :: %User{} | nil
+  @spec get_by_username(binary) :: User.t() | nil
   def get_by_username(username) do
     Repo.get_by(User, username: username)
   end

--- a/lib/notesclub/accounts/user.ex
+++ b/lib/notesclub/accounts/user.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.Accounts.User do
+  @moduledoc """
+  User schema
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/notesclub/compile.ex
+++ b/lib/notesclub/compile.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.Compile do
+  @moduledoc """
+  Compiles code conditionally
+  """
+
   defmacro only_if_loaded(library, body) do
     if Application.spec(library) do
       body[:do]

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.GithubAPI do
+  @moduledoc """
+  Fetches new notebooks from Github Search API and user data from Github Rest API
+  """
+
   alias Notesclub.GithubAPI
 
   require Logger
@@ -70,17 +74,17 @@ defmodule Notesclub.GithubAPI do
 
   @doc """
 
-  Using a given username, look up the corresponding user record from Github API 
+  Using a given username, look up the corresponding user record from Github API
 
   ## Example
   iex> Notesclub.GithubAPI.get_user_info("octocat")
   {:ok, %{twitter_username: "twitter_octo", name: "octo realname"}
 
   iex> Notesclub.GithubAPI.get_user_info(-1)
-  {:error, :not_found} 
+  {:error, :not_found}
 
   Arguments:
-  - username can be a string or a positive integer 
+  - username can be a string or a positive integer
   """
   @spec get_user_info(String.t()) :: {:ok, map()} | {:error, atom()}
   def get_user_info(username) do

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -91,12 +91,10 @@ defmodule Notesclub.GithubAPI do
   end
 
   defp extract_notebooks_data(%GithubAPI{response: response, errors: errors} = fetch) do
-    cond do
-      errors[:github_api_key] == ["is missing"] && __MODULE__.check_github_api_key() ->
-        {:error, fetch}
-
-      true ->
-        prepare_data(fetch, response.body["items"])
+    if errors[:github_api_key] == ["is missing"] && __MODULE__.check_github_api_key() do
+      {:error, fetch}
+    else
+      prepare_data(fetch, response.body["items"])
     end
   end
 
@@ -192,21 +190,19 @@ defmodule Notesclub.GithubAPI do
   defp make_request(%GithubAPI{} = fetch) do
     github_api_key = Application.get_env(:notesclub, :github_api_key)
 
-    cond do
-      github_api_key == nil && __MODULE__.check_github_api_key() ->
-        Map.put(fetch, :errors, %{github_api_key: ["is missing"]})
+    if github_api_key == nil && __MODULE__.check_github_api_key() do
+      Map.put(fetch, :errors, %{github_api_key: ["is missing"]})
+    else
+      response =
+        Req.get!(
+          fetch.url,
+          headers: [
+            Accept: ["application/vnd.github+json"],
+            Authorization: ["token #{github_api_key}"]
+          ]
+        )
 
-      true ->
-        response =
-          Req.get!(
-            fetch.url,
-            headers: [
-              Accept: ["application/vnd.github+json"],
-              Authorization: ["token #{github_api_key}"]
-            ]
-          )
-
-        Map.put(fetch, :response, response)
+      Map.put(fetch, :response, response)
     end
   end
 

--- a/lib/notesclub/github_api.ex
+++ b/lib/notesclub/github_api.ex
@@ -16,6 +16,14 @@ defmodule Notesclub.GithubAPI do
             url: nil,
             errors: %{}
 
+  @type t :: %__MODULE__{
+          notebooks_data: map(),
+          total_count: non_neg_integer(),
+          response: Req.Response.t(),
+          url: String.t(),
+          errors: map()
+        }
+
   @doc """
 
   Gets files with 'livemd' extension from GithubAPI.
@@ -52,7 +60,7 @@ defmodule Notesclub.GithubAPI do
   A common error happens when we reach GithubAPI's rate limit.
   The first .livemd file should be structs.livemd — at least on 2022-08-15.
   """
-  @spec get(options()) :: {:ok, %GithubAPI{}} | {:error, %GithubAPI{}}
+  @spec get(options()) :: {:ok, GithubAPI.t()} | {:error, GithubAPI.t()}
   def get(options) do
     options
     |> build_url()

--- a/lib/notesclub/mailer.ex
+++ b/lib/notesclub/mailer.ex
@@ -1,3 +1,7 @@
 defmodule Notesclub.Mailer do
+  @moduledoc """
+  Sends emails
+  """
+
   use Swoosh.Mailer, otp_app: :notesclub
 end

--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -23,8 +23,8 @@ defmodule Notesclub.Notebooks do
   @doc """
   Returns the latest notebook inserted
   """
-  @spec get_latest_notebook() :: %Notebook{}
-  def get_latest_notebook() do
+  @spec get_latest_notebook :: %Notebook{}
+  def get_latest_notebook do
     Notebook |> last(:inserted_at) |> Repo.one()
   end
 

--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -23,7 +23,7 @@ defmodule Notesclub.Notebooks do
   @doc """
   Returns the latest notebook inserted
   """
-  @spec get_latest_notebook :: %Notebook{}
+  @spec get_latest_notebook :: Notebook.t()
   def get_latest_notebook do
     Notebook |> last(:inserted_at) |> Repo.one()
   end

--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -29,7 +29,7 @@ defmodule Notesclub.Notebooks do
       [%Notebook{}, ...]
 
   """
-  @spec list_notebooks(any) :: [%Notebook{}]
+  @spec list_notebooks(any) :: [Notebook.t()]
   def list_notebooks(opts \\ []) do
     preload = opts[:preload] || []
 
@@ -93,7 +93,7 @@ defmodule Notesclub.Notebooks do
     |> Repo.all()
   end
 
-  @spec list_notebooks_since(integer()) :: [%Notebook{}]
+  @spec list_notebooks_since(integer()) :: [Notebook.t()]
   def list_notebooks_since(num_days_ago) when is_integer(num_days_ago) do
     from(n in Notebook,
       where: n.inserted_at >= from_now(-(^num_days_ago), "day"),
@@ -111,8 +111,8 @@ defmodule Notesclub.Notebooks do
       {:ok, %{"notebook_1" =>  %Notesclub.Notebooks.Notebook{...}, ...}}
 
   """
-  @spec enqueue_url_and_content_sync(%RepoSchema{}) ::
-          {:ok, %{binary => %Notebook{}}} | {:error, %{binary => %Ecto.Changeset{}}}
+  @spec enqueue_url_and_content_sync(RepoSchema.t()) ::
+          {:ok, %{binary => Notebook.t()}} | {:error, %{binary => Ecto.Changeset.t()}}
   def enqueue_url_and_content_sync(%RepoSchema{id: repo_id}) do
     %{repo_id: repo_id}
     |> list_notebooks()
@@ -139,7 +139,7 @@ defmodule Notesclub.Notebooks do
       [%Notebook{}, ...]
 
   """
-  @spec list_author_notebooks_desc(binary) :: [%Notebook{}] | nil
+  @spec list_author_notebooks_desc(binary) :: [Notebook.t()] | nil
   def list_author_notebooks_desc(author) when is_binary(author) do
     from(n in Notebook,
       where: n.github_owner_login == ^author,
@@ -157,7 +157,7 @@ defmodule Notesclub.Notebooks do
       [%Notebook{}, ...]
 
   """
-  @spec list_repo_author_notebooks_desc(binary, binary) :: [%Notebook{}]
+  @spec list_repo_author_notebooks_desc(binary, binary) :: [Notebook.t()]
   def list_repo_author_notebooks_desc(repo_name, author_login)
       when is_binary(repo_name) and is_binary(author_login) do
     from(n in Notebook,
@@ -199,7 +199,7 @@ defmodule Notesclub.Notebooks do
       nil
 
   """
-  @spec get_notebook(any) :: %Notebook{}
+  @spec get_notebook(any) :: Notebook.t()
   def get_notebook(id), do: Repo.get(Notebook, id)
 
   def get_notebook(id, preload: tables) do
@@ -224,7 +224,7 @@ defmodule Notesclub.Notebooks do
       ** (Ecto.NoResultsError)
 
   """
-  @spec get_notebook!(number) :: %Notebook{}
+  @spec get_notebook!(number) :: Notebook.t()
   def get_notebook!(id), do: Repo.get!(Notebook, id)
 
   def get_notebook!(id, preload: tables) do
@@ -244,7 +244,7 @@ defmodule Notesclub.Notebooks do
     true
 
   """
-  @spec get_by([...]) :: %Notebook{} | nil
+  @spec get_by([...]) :: Notebook.t() | nil
   def get_by(ops) do
     Enum.reduce(ops, from(n in Notebook), fn
       {:github_filename, github_filename}, query ->
@@ -282,7 +282,7 @@ defmodule Notesclub.Notebooks do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec create_notebook(any) :: {:ok, %Notebook{}} | {:error, %Ecto.Changeset{}}
+  @spec create_notebook(any) :: {:ok, Notebook.t()} | {:error, Ecto.Changeset.t()}
   def create_notebook(attrs \\ %{}) do
     %Notebook{}
     |> Notebook.changeset(attrs)
@@ -407,7 +407,7 @@ defmodule Notesclub.Notebooks do
   iex> save_notebook(%{field: bad_value})
   {:error, %Ecto.Changeset{}}
   """
-  @spec save_notebook(map) :: {:ok, %Notebook{}} | {:error, %Ecto.Changeset{}}
+  @spec save_notebook(map) :: {:ok, Notebook.t()} | {:error, Ecto.Changeset.t()}
   def save_notebook(attrs) do
     attrs = attrs |> put_repo_id() |> put_url()
 
@@ -498,7 +498,7 @@ defmodule Notesclub.Notebooks do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec update_notebook(%Notebook{}, map()) :: {:ok, %Notebook{}} | {:error, %Ecto.Changeset{}}
+  @spec update_notebook(Notebook.t(), map()) :: {:ok, Notebook.t()} | {:error, Ecto.Changeset.t()}
   def update_notebook(%Notebook{} = notebook, attrs) do
     notebook
     |> Notebook.changeset(attrs)
@@ -517,7 +517,7 @@ defmodule Notesclub.Notebooks do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec delete_notebook(%Notebook{}) :: {:ok, %Notebook{}} | {:error, %Ecto.Changeset{}}
+  @spec delete_notebook(Notebook.t()) :: {:ok, Notebook.t()} | {:error, Ecto.Changeset.t()}
   def delete_notebook(%Notebook{} = notebook) do
     Repo.delete(notebook)
   end
@@ -539,7 +539,7 @@ defmodule Notesclub.Notebooks do
       %Ecto.Changeset{data: %Notebook{}}
 
   """
-  @spec change_notebook(%Notebook{}, map()) :: %Ecto.Changeset{}
+  @spec change_notebook(Notebook.t(), map()) :: Ecto.Changeset.t()
   def change_notebook(%Notebook{} = notebook, attrs \\ %{}) do
     Notebook.changeset(notebook, attrs)
   end

--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -6,13 +6,13 @@ defmodule Notesclub.Notebooks do
   import Ecto.Query, warn: false
   alias Notesclub.Repo
 
-  alias Notesclub.Notebooks.Notebook
-  alias Notesclub.Repos
   alias Notesclub.Accounts
   alias Notesclub.Accounts.User
-  alias Notesclub.Repos.Repo, as: RepoSchema
   alias Notesclub.Notebooks
+  alias Notesclub.Notebooks.Notebook
   alias Notesclub.Notebooks.Urls
+  alias Notesclub.Repos
+  alias Notesclub.Repos.Repo, as: RepoSchema
 
   alias Notesclub.Workers.UrlContentSyncWorker
 

--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -545,7 +545,7 @@ defmodule Notesclub.Notebooks do
   end
 
   @spec count :: number
-  def count() do
+  def count do
     from(n in Notebook,
       select: count(n.id)
     )
@@ -598,7 +598,7 @@ defmodule Notesclub.Notebooks do
     end
   end
 
-  def update_all_titles() do
+  def update_all_titles do
     list_notebooks()
     |> Enum.map(fn n ->
       update_notebook(n, %{title: extract_title(n.content)})

--- a/lib/notesclub/notebooks/notebook.ex
+++ b/lib/notesclub/notebooks/notebook.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.Notebooks.Notebook do
+  @moduledoc """
+  Notebook schema
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/notesclub/notebooks/notebook.ex
+++ b/lib/notesclub/notebooks/notebook.ex
@@ -2,9 +2,9 @@ defmodule Notesclub.Notebooks.Notebook do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Notesclub.Searches.Search
   alias Notesclub.Accounts.User
   alias Notesclub.Repos.Repo
+  alias Notesclub.Searches.Search
 
   @optional ~w(search_id inserted_at user_id repo_id url content title)a
   @required ~w(github_filename github_html_url github_owner_login github_owner_avatar_url github_repo_name)a

--- a/lib/notesclub/notebooks/urls.ex
+++ b/lib/notesclub/notebooks/urls.ex
@@ -2,11 +2,11 @@ defmodule Notesclub.Notebooks.Urls do
   @moduledoc """
   Generate Github notebooks' urls from github_html_url
   """
+  alias Notesclub.Accounts.User
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
   alias Notesclub.Notebooks.Urls
   alias Notesclub.Repos.Repo
-  alias Notesclub.Accounts.User
 
   defstruct [
     :notebook,

--- a/lib/notesclub/notebooks/urls.ex
+++ b/lib/notesclub/notebooks/urls.ex
@@ -16,6 +16,14 @@ defmodule Notesclub.Notebooks.Urls do
     :raw_default_branch_url
   ]
 
+  @type t :: %__MODULE__{
+          notebook: Notebook.t(),
+          commit_url: String.t(),
+          raw_commit_url: String.t(),
+          default_branch_url: String.t(),
+          raw_default_branch_url: String.t()
+        }
+
   @doc """
   Generate the four notebook urls that we need
 
@@ -30,7 +38,7 @@ defmodule Notesclub.Notebooks.Urls do
       }}
 
   """
-  @spec get_urls(%Notebook{}) :: {:ok, %Urls{}} | {:error, binary()}
+  @spec get_urls(Notebook.t()) :: {:ok, Urls.t()} | {:error, binary()}
   def get_urls(nil), do: {:error, "notebook can't be nil"}
 
   def get_urls(%Notebook{repo: %Repo{default_branch: nil}}),

--- a/lib/notesclub/repos.ex
+++ b/lib/notesclub/repos.ex
@@ -20,7 +20,7 @@ defmodule Notesclub.Repos do
       [%RepoSchema{}, ...]
 
   """
-  @spec list_repos() :: [%RepoSchema{}]
+  @spec list_repos() :: [RepoSchema.t()]
   def list_repos do
     Repo.all(RepoSchema)
   end
@@ -39,7 +39,7 @@ defmodule Notesclub.Repos do
       ** (Ecto.NoResultsError)
 
   """
-  @spec get_repo!(integer) :: %RepoSchema{}
+  @spec get_repo!(integer) :: RepoSchema.t()
   def get_repo!(id), do: Repo.get!(RepoSchema, id)
 
   def get_repo!(id, preload: tables) do
@@ -72,7 +72,7 @@ defmodule Notesclub.Repos do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec create_repo(map()) :: {:ok, %RepoSchema{}} | {:error, %Ecto.Changeset{}}
+  @spec create_repo(map()) :: {:ok, RepoSchema.t()} | {:error, Ecto.Changeset.t()}
   def create_repo(attrs \\ %{}) do
     attrs
     |> Enum.into(%{
@@ -147,7 +147,7 @@ defmodule Notesclub.Repos do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec update_repo(%RepoSchema{}, map()) :: {:ok, %RepoSchema{}} | {:error, %Ecto.Changeset{}}
+  @spec update_repo(RepoSchema.t(), map()) :: {:ok, RepoSchema.t()} | {:error, Ecto.Changeset.t()}
   def update_repo(%RepoSchema{} = repo, attrs) do
     repo
     |> RepoSchema.changeset(attrs)
@@ -166,7 +166,7 @@ defmodule Notesclub.Repos do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec delete_repo(%RepoSchema{}) :: {:ok, %RepoSchema{}} | {:error, %Ecto.Changeset{}}
+  @spec delete_repo(RepoSchema.t()) :: {:ok, RepoSchema.t()} | {:error, Ecto.Changeset.t()}
   def delete_repo(%RepoSchema{} = repo) do
     Repo.delete(repo)
   end
@@ -180,7 +180,7 @@ defmodule Notesclub.Repos do
       %Ecto.Changeset{data: %Repo{}}
 
   """
-  @spec change_repo(%RepoSchema{}, map) :: %Ecto.Changeset{}
+  @spec change_repo(RepoSchema.t(), map) :: Ecto.Changeset.t()
   def change_repo(%RepoSchema{} = repo, attrs \\ %{}) do
     RepoSchema.changeset(repo, attrs)
   end
@@ -194,7 +194,7 @@ defmodule Notesclub.Repos do
       {:ok, %RepoSchema{}}
 
   """
-  @spec get_by(map) :: %RepoSchema{} | nil
+  @spec get_by(map) :: RepoSchema.t() | nil
   def get_by(params) do
     Repo.get_by(RepoSchema, params)
   end

--- a/lib/notesclub/req_tools.ex
+++ b/lib/notesclub/req_tools.ex
@@ -3,9 +3,6 @@ defmodule Notesclub.ReqTools do
   Makes an HTTP request unless we're in test env
   """
 
-  # TODO: Check how to disable all http requests by default in tests
-  # Cassettes? Mock Server depending on the url?
-  # Then, delete this
   def make_request(url) do
     case __MODULE__.requests_enabled?() do
       true -> Req.get(url)

--- a/lib/notesclub/req_tools.ex
+++ b/lib/notesclub/req_tools.ex
@@ -14,7 +14,7 @@ defmodule Notesclub.ReqTools do
   end
 
   # This function is mocked in some tests
-  def requests_enabled?() do
+  def requests_enabled? do
     case Application.get_env(:notesclub, :env) do
       :test -> false
       _ -> true

--- a/lib/notesclub/scheduler.ex
+++ b/lib/notesclub/scheduler.ex
@@ -1,3 +1,6 @@
 defmodule Notesclub.Scheduler do
+  @moduledoc """
+  Cron scheduler
+  """
   use Quantum, otp_app: :notesclub
 end

--- a/lib/notesclub/searches.ex
+++ b/lib/notesclub/searches.ex
@@ -37,7 +37,7 @@ defmodule Notesclub.Searches do
   """
   def get_search!(id), do: Repo.get!(Search, id)
 
-  def get_last_search_from_today() do
+  def get_last_search_from_today do
     from(s in Search,
       order_by: -s.id,
       limit: 1,

--- a/lib/notesclub/searches/delete.ex
+++ b/lib/notesclub/searches/delete.ex
@@ -7,11 +7,11 @@ defmodule Notesclub.Searches.Delete do
 
   # public function so we can mock it in tests
   @spec number_of_days_to_keep_search_results :: integer
-  def number_of_days_to_keep_search_results(),
+  def number_of_days_to_keep_search_results,
     do: @number_of_days_to_keep_search_results
 
   @spec eliminate :: {:ok, integer}
-  def eliminate() do
+  def eliminate do
     {count, nil} =
       Timex.now()
       |> Timex.beginning_of_day()

--- a/lib/notesclub/searches/delete.ex
+++ b/lib/notesclub/searches/delete.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.Searches.Delete do
+  @moduledoc """
+  Deletes old Search entries
+  """
+
   require Logger
 
   alias Notesclub.Searches

--- a/lib/notesclub/searches/populate.ex
+++ b/lib/notesclub/searches/populate.ex
@@ -11,13 +11,13 @@ defmodule Notesclub.Searches.Populate do
   # public function so we can mock it in tests
   def daily_page_limit, do: @daily_page_limit
 
+  alias Notesclub.Accounts
+  alias Notesclub.GithubAPI
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
-  alias Notesclub.Searches
-  alias Notesclub.Accounts
   alias Notesclub.Repos
+  alias Notesclub.Searches
   alias Notesclub.Searches.Search
-  alias Notesclub.GithubAPI
 
   @doc """
   Makes a request to fetch new notebooks from Github

--- a/lib/notesclub/searches/populate.ex
+++ b/lib/notesclub/searches/populate.ex
@@ -1,5 +1,9 @@
-# This is going to be shortened and refactored after we do https://github.com/notesclub/notesclub/issues/40
 defmodule Notesclub.Searches.Populate do
+  @moduledoc """
+  Downloads new notebooks from GitHub Search API
+  GitHub Search API sometimes does not return the page size so
+  we use Searches to keep a log and retry.
+  """
   require Logger
 
   #  max: 200 when per_page=5. Afterwards Github returns "Only the first 1000 search results are available"

--- a/lib/notesclub/searches/populate.ex
+++ b/lib/notesclub/searches/populate.ex
@@ -18,6 +18,7 @@ defmodule Notesclub.Searches.Populate do
   alias Notesclub.Repos
   alias Notesclub.Searches
   alias Notesclub.Searches.Search
+  alias Notesclub.Workers.UrlContentSyncWorker
 
   @doc """
   Makes a request to fetch new notebooks from Github
@@ -193,7 +194,7 @@ defmodule Notesclub.Searches.Populate do
   defp enqueue_url_content_sync({_, %Notebook{} = notebook} = data) do
     {:ok, _job} =
       %{notebook_id: notebook.id}
-      |> Notesclub.Workers.UrlContentSyncWorker.new()
+      |> UrlContentSyncWorker.new()
       |> Oban.insert()
 
     data

--- a/lib/notesclub/searches/populate.ex
+++ b/lib/notesclub/searches/populate.ex
@@ -75,10 +75,12 @@ defmodule Notesclub.Searches.Populate do
                page: page,
                per_page: per_page
              }) do
-          {:ok, search} ->
-            if search.response_notebooks_count == per_page do
-              save_notebooks(notebooks_data, search)
-            end
+          {:ok, search = %Search{response_notebooks_count: ^per_page}} ->
+            save_notebooks(notebooks_data, search)
+
+          {:ok, _search} ->
+            # Nothing to do...
+            :ok
 
           {:error, changeset} ->
             Logger.error(

--- a/lib/notesclub/searches/populate.ex
+++ b/lib/notesclub/searches/populate.ex
@@ -7,7 +7,7 @@ defmodule Notesclub.Searches.Populate do
   @default_per_page 5
 
   # public function so we can mock it in tests
-  def default_per_page(), do: @default_per_page
+  def default_per_page, do: @default_per_page
   # public function so we can mock it in tests
   def daily_page_limit, do: @daily_page_limit
 
@@ -26,7 +26,7 @@ defmodule Notesclub.Searches.Populate do
   When cron uses next(), every day we fetch the last @daily_page_limit indexed by GitHub
   """
   @spec next :: map
-  def next() do
+  def next do
     if Application.get_env(:notesclub, :populate_enabled) do
       Logger.info("Populate.next() start. Downloading new notebooks.")
 
@@ -57,7 +57,7 @@ defmodule Notesclub.Searches.Populate do
   When cron uses next_loop(), every day we fetch the last @daily_page_limit indexed by GitHub
   """
   @spec next_loop :: map
-  def next_loop() do
+  def next_loop do
     Logger.info("Populate.next_loop() start. Downloading new notebooks.")
 
     Searches.get_last_search_from_today()

--- a/lib/notesclub/searches/populate.ex
+++ b/lib/notesclub/searches/populate.ex
@@ -33,19 +33,17 @@ defmodule Notesclub.Searches.Populate do
       last_search_from_today = Searches.get_last_search_from_today()
       daily_page_limit = __MODULE__.daily_page_limit()
 
-      cond do
-        last_search_from_today && last_search_from_today.page >= daily_page_limit ->
-          Logger.info(
-            "Populate.next() end — reached #{daily_page_limit} daily pages. Do NOT fetch Github anymore for today"
-          )
+      if last_search_from_today && last_search_from_today.page >= daily_page_limit do
+        Logger.info(
+          "Populate.next() end — reached #{daily_page_limit} daily pages. Do NOT fetch Github anymore for today"
+        )
 
-          %{created: 0, updated: 0, downloaded: 0}
-
-        true ->
-          last_search_from_today
-          |> next_options()
-          |> populate()
-          |> log_info("Populate.next() end")
+        %{created: 0, updated: 0, downloaded: 0}
+      else
+        last_search_from_today
+        |> next_options()
+        |> populate()
+        |> log_info("Populate.next() end")
       end
     end
   end

--- a/lib/notesclub/searches/populate_recent_notebooks_worker.ex
+++ b/lib/notesclub/searches/populate_recent_notebooks_worker.ex
@@ -5,9 +5,11 @@ defmodule Notesclub.Workers.PopulateRecentNotebooksWorker do
 
   use Oban.Worker, queue: :github_search, priority: 2
 
+  alias Notesclub.Searches.Populate
+
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    result = Notesclub.Searches.Populate.next()
+    result = Populate.next()
     {:ok, result}
   end
 end

--- a/lib/notesclub/searches/search.ex
+++ b/lib/notesclub/searches/search.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.Searches.Search do
+  @moduledoc """
+  Schema to log Github Search API queries as it is unreliable
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/notesclub_web/telemetry.ex
+++ b/lib/notesclub_web/telemetry.ex
@@ -1,4 +1,8 @@
 defmodule NotesclubWeb.Telemetry do
+  @moduledoc """
+  Telemetry metrics
+  """
+
   use Supervisor
   import Telemetry.Metrics
 

--- a/lib/string_tools.ex
+++ b/lib/string_tools.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.StringTools do
+  @moduledoc """
+  Truncate strings
+  """
+
   def truncate(nil, _), do: ""
 
   def truncate(input, max_length) when is_binary(input) do

--- a/lib/workers/all_user_notebooks_sync_worker.ex
+++ b/lib/workers/all_user_notebooks_sync_worker.ex
@@ -6,13 +6,14 @@ defmodule Notesclub.Workers.AllUserNotebooksSyncWorker do
   use Oban.Worker
 
   alias Notesclub.Accounts
+  alias Notesclub.Workers.UserNotebooksSyncWorker
 
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
     Accounts.list_users()
     |> Enum.each(fn user ->
       %{username: user.username, page: 1, per_page: 100, already_saved_ids: []}
-      |> Notesclub.Workers.UserNotebooksSyncWorker.new()
+      |> UserNotebooksSyncWorker.new()
       |> Oban.insert()
     end)
 

--- a/lib/workers/repo_sync_worker.ex
+++ b/lib/workers/repo_sync_worker.ex
@@ -10,8 +10,8 @@ defmodule Notesclub.Workers.RepoSyncWorker do
     queue: :github_rest,
     unique: [period: 300, states: [:available, :scheduled, :executing]]
 
-  alias Notesclub.Repos
   alias Notesclub.Notebooks
+  alias Notesclub.Repos
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"repo_id" => repo_id}}) do

--- a/lib/workers/url_content_sync_worker.ex
+++ b/lib/workers/url_content_sync_worker.ex
@@ -30,7 +30,7 @@ defmodule Notesclub.Workers.UrlContentSyncWorker do
       {:cancel, "..."}
 
   """
-  @spec perform(%Oban.Job{}) :: {:ok, :synced} | {:cancel, binary()}
+  @spec perform(Oban.Job.t()) :: {:ok, :synced} | {:cancel, binary()}
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"notebook_id" => notebook_id}}) do

--- a/lib/workers/url_content_sync_worker.ex
+++ b/lib/workers/url_content_sync_worker.ex
@@ -11,12 +11,12 @@ defmodule Notesclub.Workers.UrlContentSyncWorker do
     queue: :default,
     unique: [period: 300, states: [:available, :scheduled, :executing]]
 
-  alias Notesclub.Workers.RepoSyncWorker
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
   alias Notesclub.Notebooks.Urls
   alias Notesclub.Repos.Repo
   alias Notesclub.ReqTools
+  alias Notesclub.Workers.RepoSyncWorker
 
   @doc """
   Sync url and content depending on notebook's urls

--- a/lib/workers/user_notebooks_sync_worker.ex
+++ b/lib/workers/user_notebooks_sync_worker.ex
@@ -5,6 +5,8 @@ defmodule Notesclub.Workers.UserNotebooksSyncWorker do
 
   alias Notesclub.GithubAPI
   alias Notesclub.Notebooks
+  alias Notesclub.Workers.UrlContentSyncWorker
+  alias Notesclub.Workers.UserNotebooksSyncWorker
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -56,7 +58,7 @@ defmodule Notesclub.Workers.UserNotebooksSyncWorker do
       {:ok, notebook} = Notebooks.save_notebook(notebook_data)
 
       %{notebook_id: notebook.id}
-      |> Notesclub.Workers.UrlContentSyncWorker.new()
+      |> UrlContentSyncWorker.new()
       |> Oban.insert()
 
       notebook.id
@@ -83,7 +85,7 @@ defmodule Notesclub.Workers.UserNotebooksSyncWorker do
           per_page: per_page,
           already_saved_ids: already_saved_ids
         }
-        |> Notesclub.Workers.UserNotebooksSyncWorker.new(priority: 2)
+        |> UserNotebooksSyncWorker.new(priority: 2)
         |> Oban.insert()
 
         {:ok, "done and enqueued another page"}

--- a/lib/workers/user_notebooks_sync_worker.ex
+++ b/lib/workers/user_notebooks_sync_worker.ex
@@ -1,4 +1,8 @@
 defmodule Notesclub.Workers.UserNotebooksSyncWorker do
+  @moduledoc """
+  Downloads and creates or updates notebooks by the given username
+  """
+
   use Oban.Worker,
     queue: :github_search,
     priority: 3

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,8 @@ defmodule Notesclub.MixProject do
       {:oban, "2.13.6"},
       {:timex, "~> 3.0"},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
-      {:redirect, "~> 0.4.0"}
+      {:redirect, "~> 0.4.0"},
+      {:credo, "~> 1.6", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/test/notesclub/notebooks/urls_test.exs
+++ b/test/notesclub/notebooks/urls_test.exs
@@ -1,12 +1,12 @@
 defmodule Notesclub.Notebooks.UrlsTest do
   use Notesclub.DataCase
 
+  alias Notesclub.AccountsFixtures
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Urls
   alias Notesclub.NotebooksFixtures
-  alias Notesclub.AccountsFixtures
-  alias Notesclub.ReposFixtures
   alias Notesclub.Repos
+  alias Notesclub.ReposFixtures
 
   setup do
     user = AccountsFixtures.user_fixture(%{username: "elixir-nx"})

--- a/test/notesclub/notebooks_test.exs
+++ b/test/notesclub/notebooks_test.exs
@@ -1,11 +1,11 @@
 defmodule Notesclub.NotebooksTest do
   use Notesclub.DataCase
 
-  alias Notesclub.Notebooks
-  alias Notesclub.SearchesFixtures
   alias Notesclub.AccountsFixtures
-  alias Notesclub.ReposFixtures
+  alias Notesclub.Notebooks
   alias Notesclub.Repos
+  alias Notesclub.ReposFixtures
+  alias Notesclub.SearchesFixtures
 
   import Notesclub.NotebooksFixtures
   import Notesclub.ReposFixtures

--- a/test/notesclub/searches/delete_test.exs
+++ b/test/notesclub/searches/delete_test.exs
@@ -1,10 +1,10 @@
 defmodule Notesclub.Searches.DeleteTest do
   use Notesclub.DataCase
 
+  alias Notesclub.Notebooks.Notebook
   alias Notesclub.Repo
   alias Notesclub.Searches.Delete
   alias Notesclub.Searches.Search
-  alias Notesclub.Notebooks.Notebook
 
   import Notesclub.SearchesFixtures
   import Notesclub.NotebooksFixtures

--- a/test/notesclub/searches/populate_test.exs
+++ b/test/notesclub/searches/populate_test.exs
@@ -1,12 +1,12 @@
 defmodule Notesclub.Searches.PopulateTest do
   use Notesclub.DataCase
 
-  alias Notesclub.Searches
-  alias Notesclub.Searches.Search
-  alias Notesclub.Searches.Populate
   alias Notesclub.GithubAPI
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
+  alias Notesclub.Searches
+  alias Notesclub.Searches.Populate
+  alias Notesclub.Searches.Search
 
   import Mock
 

--- a/test/notesclub/workers/repo_sync_worker_test.exs
+++ b/test/notesclub/workers/repo_sync_worker_test.exs
@@ -3,11 +3,11 @@ defmodule RepoSyncWorkerTest do
 
   import Mock
 
-  alias Notesclub.Workers.RepoSyncWorker
-  alias Notesclub.ReposFixtures
+  alias Notesclub.Notebooks
   alias Notesclub.NotebooksFixtures
   alias Notesclub.Repos
-  alias Notesclub.Notebooks
+  alias Notesclub.ReposFixtures
+  alias Notesclub.Workers.RepoSyncWorker
 
   @github_repo_response %Req.Response{
     status: 200,

--- a/test/notesclub/workers/url_content_sync_worker_test.exs
+++ b/test/notesclub/workers/url_content_sync_worker_test.exs
@@ -3,12 +3,12 @@ defmodule UrlContentSyncWorkerTest do
 
   import Mock
 
-  alias Notesclub.Workers.UrlContentSyncWorker
   alias Notesclub.AccountsFixtures
-  alias Notesclub.ReposFixtures
-  alias Notesclub.NotebooksFixtures
   alias Notesclub.Notebooks
+  alias Notesclub.NotebooksFixtures
+  alias Notesclub.ReposFixtures
   alias Notesclub.ReqTools
+  alias Notesclub.Workers.UrlContentSyncWorker
 
   @valid_response %Req.Response{
     status: 200,

--- a/test/notesclub/workers/user_notebooks_sync_worker_test.exs
+++ b/test/notesclub/workers/user_notebooks_sync_worker_test.exs
@@ -3,10 +3,10 @@ defmodule Notesclub.Workers.UserNotebooksSyncWorkerTest do
 
   import Mock
 
+  alias Notesclub.GithubAPI
   alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
   alias Notesclub.Workers.UserNotebooksSyncWorker
-  alias Notesclub.GithubAPI
 
   @github_response %Req.Response{
     status: 200,

--- a/test/notesclub/workers/user_sync_worker_test.exs
+++ b/test/notesclub/workers/user_sync_worker_test.exs
@@ -3,9 +3,9 @@ defmodule UserSyncWorkerTest do
 
   import Mock
 
-  alias Notesclub.{Accounts, AccountsFixtures, GithubAPI}
-  alias Notesclub.Workers.UserSyncWorker
   alias Notesclub.GithubAPI
+  alias Notesclub.Workers.UserSyncWorker
+  alias Notesclub.{Accounts, AccountsFixtures, GithubAPI}
 
   @github_user_response %Req.Response{
     status: 200,

--- a/test/support/date_tools.ex
+++ b/test/support/date_tools.ex
@@ -1,4 +1,8 @@
 defmodule DateTools do
+  @moduledoc """
+  Date helpers
+  """
+
   def days_ago(num_days) do
     NaiveDateTime.utc_now() |> NaiveDateTime.add(-60 * 60 * 24 * num_days)
   end


### PR DESCRIPTION
Elixir code is now linted with credo to enforce code consistency. See the commit messages and descriptions for details on the changes.