### PR TITLE
Fix warnings for unused code

### DIFF
--- a/lib/notesclub/notebooks/urls.ex
+++ b/lib/notesclub/notebooks/urls.ex
@@ -3,7 +3,6 @@ defmodule Notesclub.Notebooks.Urls do
   Generate Github notebooks' urls from github_html_url
   """
   alias Notesclub.Accounts.User
-  alias Notesclub.Notebooks
   alias Notesclub.Notebooks.Notebook
   alias Notesclub.Notebooks.Urls
   alias Notesclub.Repos.Repo

--- a/lib/workers/repo_sync_worker.ex
+++ b/lib/workers/repo_sync_worker.ex
@@ -53,7 +53,6 @@ defmodule Notesclub.Workers.RepoSyncWorker do
     {:error, "response status: #{status}, msg: #{response.body["message"]}"}
   end
 
-  defp update_repo({:error, error}), do: {:error, error}
   defp update_repo(%{default_branch: nil}, _), do: {:error, "default_branch is empty"}
   defp update_repo(%{default_branch: ""}, _), do: {:error, "default_branch is empty"}
   defp update_repo(%{fork: nil}, _), do: {:error, "fork is nil"}


### PR DESCRIPTION
The warnings showed up when compiling the code:

```
warning: function update_repo/1 is unused
lib/workers/repo_sync_worker.ex:56
```

`update_repo({:error, error})` could never match since a Map is always passed to `update_repo/1`.

```
warning: unused alias Notebooks
lib/notesclub/notebooks/urls.ex:6
```

Nothing from `Notebooks` was called, so the alias can be removed from `lib/notesclub/notebooks/urls.ex`.