### PR TITLE
Add types to Ecto Schemas

### DIFF
--- a/lib/notesclub/accounts/user.ex
+++ b/lib/notesclub/accounts/user.ex
@@ -3,10 +3,10 @@ defmodule Notesclub.Accounts.User do
   User schema
   """
 
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
-  schema "users" do
+  typed_schema "users" do
     field :username, :string
     field :avatar_url, :string
     field :name, :string

--- a/lib/notesclub/notebooks/notebook.ex
+++ b/lib/notesclub/notebooks/notebook.ex
@@ -3,7 +3,7 @@ defmodule Notesclub.Notebooks.Notebook do
   Notebook schema
   """
 
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
   alias Notesclub.Accounts.User
@@ -13,7 +13,7 @@ defmodule Notesclub.Notebooks.Notebook do
   @optional ~w(search_id inserted_at user_id repo_id url content title)a
   @required ~w(github_filename github_html_url github_owner_login github_owner_avatar_url github_repo_name)a
 
-  schema "notebooks" do
+  typed_schema "notebooks" do
     field :url, :string
     field :content, :string
     field :title, :string, default: ""

--- a/lib/notesclub/repos/repo.ex
+++ b/lib/notesclub/repos/repo.ex
@@ -1,9 +1,9 @@
 defmodule Notesclub.Repos.Repo do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
   alias Notesclub.Accounts.User
 
-  schema "repos" do
+  typed_schema "repos" do
     field :name, :string
     field :full_name, :string
     field :default_branch, :string

--- a/lib/notesclub/searches/search.ex
+++ b/lib/notesclub/searches/search.ex
@@ -3,12 +3,12 @@ defmodule Notesclub.Searches.Search do
   Schema to log Github Search API queries as it is unreliable
   """
 
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
 
   alias Notesclub.Notebooks.Notebook
 
-  schema "searches" do
+  typed_schema "searches" do
     field :order, :string
     field :page, :integer
     field :per_page, :integer

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,8 @@ defmodule Notesclub.MixProject do
       {:timex, "~> 3.0"},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:redirect, "~> 0.4.0"},
-      {:credo, "~> 1.6", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
+      {:typed_ecto_schema, "~> 0.4.1", runtime: false}
     ]
   end
 


### PR DESCRIPTION
This fixes errors found by dialyzer, such as:

```
lib/notesclub/repos.ex:75:unknown_type
Unknown type: Notesclub.Repos.Repo.t/0
```

Part of #105, there are still more errors to be fixed, but it went from 47 to 16 errors.