### PR TITLE
Fix Dialyzer error "Callback info about the Mix.Task behaviour is not available"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule Notesclub.MixProject do
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      dialyzer: [plt_add_apps: [:mix]]
     ]
   end
 


### PR DESCRIPTION
The exact error message was:

```
lib/mix/tasks/insert_users_and_repos.ex:1:callback_info_missing
Callback info about the Mix.Task behaviour is not available.
```

I have found the fix here:
https://stackoverflow.com/questions/51208388/how-to-fix-dialyzer-callback-info-about-the-behaviour-is-not-available

Part of #105