### PR TITLE
Fix livebook links mobile view in show page

### DIFF
--- a/lib/notesclub_web/live/notebook_live/show.html.heex
+++ b/lib/notesclub_web/live/notebook_live/show.html.heex
@@ -8,7 +8,7 @@
   <h2 class="text-sm text-center text-gray-900 mt-4"><%= file(@notebook) %></h2>
 
   <section class="sm:w-3/4 w-11/12 mx-auto overflow-x-hidden pt-8">
-    <div class="flex flex-1 pb-4">
+    <div class="flex flex-1 pb-4 flex-col md:flex-row">
       <div class="flex-shrink-0">
         <.live_component
           module={NotesclubWeb.NotebookLive.UserComponent}
@@ -16,20 +16,22 @@
           id="u"
         />
       </div>
-      <div class="pt-2 pl-4">
-        <.link href={"https://livebook.dev/run?url=#{@notebook.github_html_url}"} target="_blank">
-          <%= img_tag static_path(@socket, "/images/run_in_livebook.svg"), class: "h-8 rounded-full", alt: "avatar" %>
-        </.link>
-      </div>
-      <div class="pt-2 pl-4">
-        <.link href={@notebook.github_html_url} target="_blank">
-          <%= img_tag static_path(@socket, "/images/github-logo.svg"), class: "h-8 rounded-full", alt: "avatar" %>
-        </.link>
-      </div>
-      <div class="pt-3 pl-4">
-        <.link navigate={~p"/"} class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-          More notebooks
-        </.link>
+      <div class="flex flex-wrap">
+        <div class="pt-2 pl-4">
+          <.link href={"https://livebook.dev/run?url=#{@notebook.github_html_url}"} target="_blank">
+            <%= img_tag static_path(@socket, "/images/run_in_livebook.svg"), class: "h-8 rounded-full", alt: "avatar" %>
+          </.link>
+        </div>
+        <div class="pt-2 pl-4">
+          <.link href={@notebook.github_html_url} target="_blank">
+            <%= img_tag static_path(@socket, "/images/github-logo.svg"), class: "h-8 rounded-full", alt: "avatar" %>
+          </.link>
+        </div>
+        <div class="pt-3 pl-4">
+          <.link navigate={~p"/"} class="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+            More notebooks
+          </.link>
+        </div>
       </div>
     </div>
     <div class="px-4 markdown" id="content" phx-hook="mermaidDiagrams">


### PR DESCRIPTION
The livebook links look broken in mobile view. This PR fixes it.

## Before

![Screenshot from 2023-07-10 23-07-28](https://github.com/notesclub/notesclub/assets/54525741/07b2f092-c967-40a4-b0c1-71ccea657598)
![Screenshot from 2023-07-10 23-07-33](https://github.com/notesclub/notesclub/assets/54525741/392fd4e4-ffe7-440c-a0dc-1c980366a06b)

## After

I wasn't able to add sample notebooks locally. I managed to cobble around the codebase and put in demo data.

![Screenshot from 2023-07-10 23-06-59](https://github.com/notesclub/notesclub/assets/54525741/19bcbecc-58e3-4588-b04f-edbc4719d548)
![Screenshot from 2023-07-10 23-07-07](https://github.com/notesclub/notesclub/assets/54525741/cdf26724-11d9-4ed7-8d6d-3a20fe4e531a)
![Screenshot from 2023-07-10 23-07-14](https://github.com/notesclub/notesclub/assets/54525741/b7adb044-2aa6-4a9c-a7d1-3ae515eb2c10)

@hectorperez let me know what you think!