### PR TITLE
refactor: Notesclub.Notebooks.count/0 function

### DIFF
--- a/lib/notesclub/notebooks.ex
+++ b/lib/notesclub/notebooks.ex
@@ -624,10 +624,7 @@ defmodule Notesclub.Notebooks do
 
   @spec count :: number
   def count do
-    from(n in Notebook,
-      select: count(n.id)
-    )
-    |> Repo.one()
+    Repo.aggregate(Notebook, :count, :id)
   end
 
   def content_fragment(%Notebook{content: nil}, _search), do: nil


### PR DESCRIPTION
A very small refactoring in [`Notesclub.Notebooks.count/0`](https://github.com/notesclub/notesclub/blob/37ad7bc2e2c27b08c0327effc6e67fd5db3552ca/lib/notesclub/notebooks.ex#L626) function.